### PR TITLE
Extract Azure BLOB metadata

### DIFF
--- a/llama_hub/azstorage_blob/base.py
+++ b/llama_hub/azstorage_blob/base.py
@@ -167,7 +167,7 @@ class AzStorageBlobReader(BaseReader):
                 extracted_meta.update(meta.get("metadata") or {})
                 extracted_meta.update(meta.get("tags") or {})
                 return extracted_meta
-            
+
             loader = SimpleDirectoryReader(
                 temp_dir,
                 file_extractor=self.file_extractor,

--- a/llama_hub/azstorage_blob/base.py
+++ b/llama_hub/azstorage_blob/base.py
@@ -83,15 +83,18 @@ class AzStorageBlobReader(BaseReader):
                 self.account_url, self.container_name, credential=self.credential
             )
         total_download_start_time = time.time()
+        blob_meta = {}
 
         with tempfile.TemporaryDirectory() as temp_dir:
             if self.blob:
-                stream = container_client.download_blob(self.blob)
+                blob_client = container_client.get_blob_client(self.blob)
+                stream = blob_client.download_blob()
                 download_file_path = f"{temp_dir}/{stream.name}"
                 logger.info(f"Start download of {self.blob}")
                 start_time = time.time()
                 with open(file=download_file_path, mode="wb") as download_file:
                     stream.readinto(download_file)
+                blob_meta[download_file_path] = blob_client.get_blob_properties()
                 end_time = time.time()
                 logger.info(
                     f"{self.blob} downloaded in {end_time - start_time} seconds."
@@ -107,9 +110,11 @@ class AzStorageBlobReader(BaseReader):
                     download_file_path = f"{temp_dir}/{obj.name}"
                     logger.info(f"Start download of {obj.name}")
                     start_time = time.time()
-                    stream = container_client.download_blob(obj)
+                    blob_client = container_client.get_blob_client(obj)
+                    stream = blob_client.download_blob()
                     with open(file=download_file_path, mode="wb") as download_file:
                         stream.readinto(download_file)
+                    blob_meta[download_file_path] = blob_client.get_blob_properties()
                     end_time = time.time()
                     logger.info(
                         f"{obj.name} downloaded in {end_time - start_time} seconds."
@@ -131,6 +136,42 @@ class AzStorageBlobReader(BaseReader):
                 SimpleDirectoryReader = import_loader("SimpleDirectoryReader")
             except ImportError:
                 SimpleDirectoryReader = download_loader("SimpleDirectoryReader")
-            loader = SimpleDirectoryReader(temp_dir, file_extractor=self.file_extractor)
+
+            def extract_blob_meta(file_path):
+                meta: dict = blob_meta[file_path]
+
+                creation_time = meta.get("creation_time")
+                creation_time = (
+                    creation_time.strftime("%Y-%m-%d") if creation_time else None
+                )
+
+                last_modified = meta.get("last_modified")
+                last_modified = (
+                    last_modified.strftime("%Y-%m-%d") if last_modified else None
+                )
+
+                last_accessed_on = meta.get("last_accessed_on")
+                last_accessed_on = (
+                    last_accessed_on.strftime("%Y-%m-%d") if last_accessed_on else None
+                )
+
+                extracted_meta = {
+                    "file_name": meta.get("name"),
+                    "file_type": meta.get("content_settings", {}).get("content_type"),
+                    "file_size": meta.get("size"),
+                    "creation_date": creation_time,
+                    "last_modified_date": last_modified,
+                    "last_accessed_date": last_accessed_on,
+                    "container": meta.get("container"),
+                }
+                extracted_meta.update(meta.get("metadata") or {})
+                extracted_meta.update(meta.get("tags") or {})
+                return extracted_meta
+            
+            loader = SimpleDirectoryReader(
+                temp_dir,
+                file_extractor=self.file_extractor,
+                file_metadata=extract_blob_meta,
+            )
 
             return loader.load_data()


### PR DESCRIPTION
Extract useful system-generated metadata from Azure BLOB and user-defined metadata and tags.

# Description

The changes from this PR extract metadata from Azure BLOB entities. Before this PR the `llama_index.readers.file.base.default_file_metadata_func` was used for metadata extraction. However, since the data is downloaded to the host system, the extracted metadata may not be correct.

This PR implements metadata extraction directly from Azure BLOB properties which consists of system metadata (e.g. `creation_time`) and user-defined metadata (as `metadata` and `tags`).

The new metadata set equals to the one obtained by the default metadata extractor + other Azure system meta + user-defined meta.

No dependencies have been changed.


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix / Smaller change

# How Has This Been Tested?

This has been tested with Azure Storage Blob (authenticated with connection string) and a Python script.
Example:

```python
from llama_hub.azstorage_blob import AzStorageBlobReader

reader = AzStorageBlobReader(container_name="the-container-name", connection_string="conn-str")
documents = reader.load_data()

documents[0].metadata
{'page_label': '1', 'file_name': 'some_file_name.pdf', 'file_type': 'application/pdf', 'file_size': 1093814, 'creation_date': '2023-12-20', 'last_modified_date': '2023-12-21', 'last_accessed_date': None, 'container': 'the-container-name', 'source_url': 'this-is-user-defined-meta'}
```

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods